### PR TITLE
Optimize valid extensions (+ uppercase) loop

### DIFF
--- a/dotconfig/__init__.py
+++ b/dotconfig/__init__.py
@@ -54,14 +54,13 @@ class Config(object):
             if not os.path.isdir(self.base_dir):
                 os.makedirs(self.base_dir)
 
-            for ext in VALID_EXT:
-                for _ext in [ext, ext.upper()]:
-                    filename = '{}.{}'.format(name, _ext)
-                    cfg = os.path.join(self.base_dir, filename)
-                    if os.path.isfile(cfg):
-                        self.full_path = cfg
-                        self.filename = filename
-                        break
+            for ext in [ext for t in zip(VALID_EXT, [item.upper() for item in VALID_EXT]) for ext in t]:
+                filename = '{}.{}'.format(name, ext)
+                cfg = os.path.join(self.base_dir, filename)
+                if os.path.isfile(cfg):
+                    self.full_path = cfg
+                    self.filename = filename
+                    break
 
             if self.filename is None:
                 self.filename = name + '.' + VALID_EXT[0]

--- a/dotconfig/__init__.py
+++ b/dotconfig/__init__.py
@@ -2,6 +2,7 @@
 import yaml
 import os
 import shutil
+import itertools
 
 
 VALID_EXT = [
@@ -54,7 +55,7 @@ class Config(object):
             if not os.path.isdir(self.base_dir):
                 os.makedirs(self.base_dir)
 
-            for ext in [ext for t in zip(VALID_EXT, [item.upper() for item in VALID_EXT]) for ext in t]:
+            for ext in itertools.chain(VALID_EXT, map(str.upper, VALID_EXT)):
                 filename = '{}.{}'.format(name, ext)
                 cfg = os.path.join(self.base_dir, filename)
                 if os.path.isfile(cfg):


### PR DESCRIPTION
When searching for the settings file, Config class [iterates](https://github.com/adammhaile/dotconfig/blob/master/dotconfig/__init__.py#L57) over valid extensions `('yaml', 'yml', 'json')` and their uppercase versions. In each iteration, it then checks that a settings file exists with current iteration; if it does, it sets internally the path to the settings file. The loop should then be terminated, but since the code uses two nested loops, it keeps iterating over all remaining extensions: the `break` statement has not the desired effect